### PR TITLE
Internal server error with invalid url

### DIFF
--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -49,7 +49,7 @@ class QuotesController < ApplicationController
   private
   def validate_url
     unless params[:u] =~ /^#{URI::regexp(%w(http https))}$/
-      redirect_to root_path
+      render status: 404, text: '404 Not found'
     end
   end
 end

--- a/spec/controllers/quotes_controller_spec.rb
+++ b/spec/controllers/quotes_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe QuotesController do
   context 'show' do
     before { get :show, :u => nil }
-    it { should redirect_to(:controller => 'top', :action => 'index') }
+    subject { response }
+    its(:response_code) { should eq 404 }
   end
 end


### PR DESCRIPTION
If you quote with empty url, QuoteIt returns 500 status code.
It it not cool.
