### PR TITLE
iTMS quote rule cannot quote some songs

### DIFF
--- a/config/quote_it.json
+++ b/config/quote_it.json
@@ -142,7 +142,7 @@
     {
       "regexp": "https?:\\/\\/itunes\\.apple\\.com\\/(\\w+)\\/(\\w+)/(.+)/id(\\d+)(.*)",
       "clip": "http://itunes.apple.com/lookup?country=$1&id=$4",
-      "transform": "track = \"#{json['results'][0]['trackName'] || json['results'][0]['collectionName']} - #{json['results'][0]['artistName']}\".gsub('&', '&')\r\n\"<a class='quote-it thumbnail' target='_blank' href='#{original_url}' ><img style='height:100px' src='#{json['results'][0]['artworkUrl100']}' /> #{track}</a>\"",
+      "transform": "track = \"#{json['results'][0]['trackName'] || json['results'][0]['collectionName']} - #{json['results'][0]['artistName']}\".gsub('&', '&amp;')\r\n\"<a class='quote-it thumbnail' target='_blank' href='#{original_url}' ><img style='height:100px' src='#{json['results'][0]['artworkUrl100']}' /> #{track}</a>\"",
       "service": {
         "name": "iTunes Preview",
         "url": "https://itunes.apple.com/"


### PR DESCRIPTION
Yuka Kusakabe (草壁ゆか) is a great artist.
So I think that Code-less Telephone (コードレス☆照れ☆PHONE) should be more spread.
https://itunes.apple.com/jp/album/tvanimeshon-nourin-cha-ru/id793576243

When I quote the song, HTMLs generated by QuoteIt contain '&' character, it breaks XHTML based applications.
The plugin system of [AsakusaSatellite](https://github.com/codefirst/AsakusaSatellite) is based on XHTML, so we cannot quote the great song :cry:

I suggest that generated HTMLs should contain  '&amp;amp;' instead of '&'.
