### PR TITLE
bundle update libv8 to install on yosemite (10.10.1, 10.10.2 DP)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     less-rails (2.4.2)
       actionpack (>= 3.1)
       less (~> 2.4.0)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)


### PR DESCRIPTION
same issue as AsakusaSatellite.
https://github.com/codefirst/AsakusaSatellite/pull/206
