### PR TITLE
og:url sometimes lies their URL

### DIFF
--- a/app/models/html_rule.rb
+++ b/app/models/html_rule.rb
@@ -73,7 +73,7 @@ class HtmlRule < ActiveRecord::Base
 	if graph then
 	  <<END
 <div class='quote-it clip opengraph' style="border-radius: 5px 5px 5px 5px; box-shadow: 1px 1px 2px #999999; padding: 10px;">
-#{image_tag(graph)}#{title_tag(graph)}#{description_tag(graph)}</div>
+#{image_tag(url, graph)}#{title_tag(url, graph)}#{description_tag(graph)}</div>
 END
       end
     end
@@ -85,25 +85,25 @@ END
       end
     end
 
-    def image_tag(graph)
+    def image_tag(url, graph)
       return '' if graph.images.empty?
       return <<-HTML
   <div>
-    <a href="#{escapeHTML graph.url}" class="quote-it thumbnail" target="_blank">
+    <a href="#{escapeHTML url}" class="quote-it thumbnail" target="_blank">
       <img src="#{escapeHTML graph.images.first}" style="max-height: 100px" />
     </a>
   </div>
       HTML
     end
 
-    def title_tag(graph)
+    def title_tag(url, graph)
       if !graph.title.blank?
         return <<-HTML
-  <div><a href="#{escapeHTML graph.url}" target="_blank">#{escapeHTML graph.title}</a></div>
+  <div><a href="#{escapeHTML url}" target="_blank">#{escapeHTML graph.title}</a></div>
         HTML
       elsif graph.images.empty?
         return <<-HTML
-  <div><a href="#{escapeHTML graph.url}" target="_blank">#{escapeHTML graph.url}</a></div>
+  <div><a href="#{escapeHTML url}" target="_blank">#{escapeHTML url}</a></div>
         HTML
       else
         return ''

--- a/spec/models/html_rule_spec.rb
+++ b/spec/models/html_rule_spec.rb
@@ -187,6 +187,7 @@ describe HtmlRule do
         it { should_not be_include 'title' }
         it { should be_include '<img' }
       end
+
       context "and without img" do
         before do
           allow(OpenGraph).to receive(:new) {
@@ -198,6 +199,21 @@ describe HtmlRule do
         end
         subject { HtmlRule.quote 'http://hoge.com' }
         it { should be_include 'http://hoge.com' }
+        it { should_not be_include 'img' }
+        it { should_not be_include 'title' }
+      end
+
+      context "ignore redirect" do
+        before do
+          allow(OpenGraph).to receive(:new) {
+            OpenStruct.new(
+              :images => [],
+              :url => 'http://another.com'
+            )
+          }
+        end
+        subject { HtmlRule.quote 'http://original.com' }
+        it { should be_include 'http://original.com' }
         it { should_not be_include 'img' }
         it { should_not be_include 'title' }
       end


### PR DESCRIPTION
http://www.gochiusa.com/news/hp0001/index02670000.html
Ah＾～ It makes my heart keep hopping＾～

In this page, there is a serious problem.
Quoted URL looks like wrong, because the ```og:url``` in this page is ```http://www.gochiusa.com/```.

It is better that original URLs are used instead of ```og:url```s.