### PR TITLE
Hack to return XHTML from twitter 

### DIFF
--- a/config/quote_it.json
+++ b/config/quote_it.json
@@ -295,7 +295,7 @@
     {
       "regexp": "https?:\\/\\/(?:mobile\\.)?twitter\\.com\\/(?:#!\\/)?[a-zA-Z0-9_]+\\/status(?:es)?\\/([0-9]+)",
       "clip": "https://api.twitter.com/1/statuses/oembed.json?id=$1",
-      "transform": "json['html'].gsub(\"<script async\", \"<script async=\\\"async\\\"\")",
+      "transform": "json['html'].gsub(\"<script async\", \"<script async=\\\"async\\\"\").gsub('<br>', '<br />')",
       "service": {
         "name": "Twitter",
         "url": "http://twitter.com"

--- a/wercker.yml
+++ b/wercker.yml
@@ -24,7 +24,8 @@ build:
           url: $DASHBOZU_URL
 deploy:
     steps:
-        - heroku-deploy
+        - heroku-deploy:
+            install-toolbelt: true
         - script:
             name: Update database
             code: |


### PR DESCRIPTION
some tweet(e.g. https://twitter.com/k0koro_091/status/706379930972499968) contains `<br>` tag. But some app, including as, can only treat XHTML.

To fix this gap, I add a `gsub`.