### PR TITLE
Fix video links to XHTML

### DIFF
--- a/config/quote_it.json
+++ b/config/quote_it.json
@@ -322,7 +322,7 @@
     {
       "regexp": "(.*\\.(?:mp4|mov)\\z)",
       "clip": null,
-      "transform": "\"<video src='#{original_url}' controls style='width:480px'></video>\"",
+      "transform": "\"<video src='#{original_url}' controls='controls' style='width:480px'></video>\"",
       "service": {
         "url": "",
         "name": "Direct Link(mp4)"


### PR DESCRIPTION
[AsakusaSatellite](https://github.com/codefirst/AsakusaSatellite) requires XHTML! So #28 is not enough.
